### PR TITLE
Include DOCTYPE and page language

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -1,4 +1,5 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
Conformance checking against HTML5 shows a missing doctype and page language. Consider adding them for not only this page, but for all the other countries too.

````
<!DOCTYPE html>
<html lang="en">