### PR TITLE
Bugfix: Split independent regions of the Netherlands

### DIFF
--- a/lib/CovidObserver/Data.rakumod
+++ b/lib/CovidObserver/Data.rakumod
@@ -50,6 +50,10 @@ sub extract-covid-data($data) is export {
     while my @row = $csv.getline($fh) {
         my $country = @row[1] || '';
 
+        if $country eq 'Netherlands' {
+            $country = @row[0] || '';
+        }
+
         my $cc = country2cc($country);
         next unless $cc;
 


### PR DESCRIPTION
Aruba, Curacao, Sint Maarten are independ territories of the Netherlands
with own government structures. Additionally, they are located in Latin
America and not Europe. This skews the figures for both Europe and Latin
America.